### PR TITLE
Feat: account認証付きupdate・delete

### DIFF
--- a/src/main/java/com/example/moneyAllocation/controller/AccountController.java
+++ b/src/main/java/com/example/moneyAllocation/controller/AccountController.java
@@ -50,7 +50,8 @@ public class AccountController {
     }
 
     @PatchMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void set(@RequestBody Account account) {
+    public void set(@AuthenticationPrincipal LoginUserDetails loginUserDetails, @RequestBody Account account) {
+        account.setOwnerId(loginUserDetails.getLoginUser().id());
         this.service.set(account);
     }
 

--- a/src/main/java/com/example/moneyAllocation/controller/AccountController.java
+++ b/src/main/java/com/example/moneyAllocation/controller/AccountController.java
@@ -56,8 +56,11 @@ public class AccountController {
     }
 
     @DeleteMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public void delete(@PathVariable Long id) {
-        this.service.delete(id);
+    public void delete(@AuthenticationPrincipal LoginUserDetails loginUserDetails, @PathVariable Long id) {
+        AccountSelector selector = new AccountSelector();
+        selector.setId(id);
+        selector.setOwnerId(loginUserDetails.getLoginUser().id());
+        this.service.delete(selector);
     }
 }
 

--- a/src/main/java/com/example/moneyAllocation/repository/AccountRepository.java
+++ b/src/main/java/com/example/moneyAllocation/repository/AccountRepository.java
@@ -12,5 +12,5 @@ public interface AccountRepository {
 
     void set(Account account);
 
-    void delete(Long id);
+    void delete(AccountSelector selector);
 }

--- a/src/main/java/com/example/moneyAllocation/repository/AccountRepositoryImpl.java
+++ b/src/main/java/com/example/moneyAllocation/repository/AccountRepositoryImpl.java
@@ -47,8 +47,8 @@ public class AccountRepositoryImpl implements AccountRepository {
     }
 
     @Override
-    public void delete(Long id) {
-        int affected = this.sqlSession.getMapper(AccountMapper.class).delete(id);
+    public void delete(AccountSelector selector) {
+        int affected = this.sqlSession.getMapper(AccountMapper.class).delete(selector);
         if (affected != 1) {
             throw new ResourceNotFoundException("Account not found");
         }

--- a/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.java
+++ b/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.java
@@ -4,7 +4,6 @@ import com.example.moneyAllocation.domain.Account;
 import com.example.moneyAllocation.domain.AccountSelector;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface AccountMapper {
@@ -16,5 +15,5 @@ public interface AccountMapper {
 
     int set(Account account);
 
-    int delete(@Param("id") Long id);
+    int delete(AccountSelector selector);
 }

--- a/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.xml
+++ b/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.xml
@@ -81,6 +81,8 @@
 
     <delete id="delete" parameterType="Long">
         DELETE FROM ACCOUNT
-        WHERE ID = #{id};
+        WHERE
+        ID = #{id}
+        AND OWNER_ID = #{ownerId}
     </delete>
 </mapper>

--- a/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.xml
+++ b/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.xml
@@ -75,7 +75,8 @@
         TRANSFER_FEE = #{transferFee},
         OWNER_ID = #{ownerId}
         WHERE
-        ID = #{id};
+        ID = #{id}
+        AND OWNER_ID = #{ownerId}
     </update>
 
     <delete id="delete" parameterType="Long">

--- a/src/main/java/com/example/moneyAllocation/service/AccountService.java
+++ b/src/main/java/com/example/moneyAllocation/service/AccountService.java
@@ -13,5 +13,5 @@ public interface AccountService {
 
     void set(Account account);
 
-    void delete(Long id);
+    void delete(AccountSelector selector);
 }

--- a/src/main/java/com/example/moneyAllocation/service/AccountServiceImpl.java
+++ b/src/main/java/com/example/moneyAllocation/service/AccountServiceImpl.java
@@ -35,7 +35,7 @@ public class AccountServiceImpl implements AccountService {
     }
 
     @Override
-    public void delete(Long id) {
-        accountRepository.delete(id);
+    public void delete(AccountSelector selector) {
+        accountRepository.delete(selector);
     }
 }

--- a/src/test/java/com/example/moneyAllocation/repository/AccountRepositoryImplDbUnitTest.java
+++ b/src/test/java/com/example/moneyAllocation/repository/AccountRepositoryImplDbUnitTest.java
@@ -190,8 +190,10 @@ public class AccountRepositoryImplDbUnitTest {
 
         @Test
         public void testDeleteNotExistsId() {
-            Long accountId = 8L;
-            assertThrows(ResourceNotFoundException.class, () -> repository.delete(accountId));
+            AccountSelector selector = new AccountSelector();
+            selector.setId(6L);
+            selector.setOwnerId(1L);
+            assertThrows(ResourceNotFoundException.class, () -> repository.delete(selector));
         }
     }
 }

--- a/src/test/java/com/example/moneyAllocation/repository/AccountRepositoryImplTest.java
+++ b/src/test/java/com/example/moneyAllocation/repository/AccountRepositoryImplTest.java
@@ -24,13 +24,12 @@ class AccountRepositoryImplTest {
     @Mock
     AccountMapper mapper;
 
-    private AutoCloseable mocks;
 
     private AccountRepository repository;
 
     @BeforeEach
     public void before() {
-        mocks = MockitoAnnotations.openMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.doReturn(mapper).when(sqlSession).getMapper(AccountMapper.class);
         repository = new AccountRepositoryImpl(sqlSession);
     }
@@ -68,7 +67,6 @@ class AccountRepositoryImplTest {
 
     @Test
     void findOneNotExists() {
-        Account account = new Account();
         AccountSelector selector = new AccountSelector();
         selector.setId(1L);
         selector.setOwnerId(1L);
@@ -114,16 +112,16 @@ class AccountRepositoryImplTest {
 
     @Test
     void delete() {
-        Long deleteId = 1L;
-        Mockito.doReturn(1).when(mapper).delete(deleteId);
-        this.repository.delete(deleteId);
-        Mockito.verify(mapper, Mockito.times(1)).delete(deleteId);
+        AccountSelector selector = new AccountSelector();
+        Mockito.doReturn(1).when(mapper).delete(selector);
+        this.repository.delete(selector);
+        Mockito.verify(mapper, Mockito.times(1)).delete(selector);
     }
     @Test
     void deleteFail() {
-        Long deleteId = 1L;
-        Mockito.doReturn(0).when(mapper).delete(deleteId);
-        assertThrowsExactly(ResourceNotFoundException.class, () -> this.repository.delete(deleteId));
-        Mockito.verify(mapper, Mockito.times(1)).delete(deleteId);
+        AccountSelector selector = new AccountSelector();
+        Mockito.doReturn(0).when(mapper).delete(selector);
+        assertThrowsExactly(ResourceNotFoundException.class, () -> this.repository.delete(selector));
+        Mockito.verify(mapper, Mockito.times(1)).delete(selector);
     }
 }

--- a/src/test/java/com/example/moneyAllocation/service/AccountServiceImplTest.java
+++ b/src/test/java/com/example/moneyAllocation/service/AccountServiceImplTest.java
@@ -76,9 +76,9 @@ class AccountServiceImplTest {
 
     @Test
     void delete() {
-        Long id = 2L;
-        Mockito.doNothing().when(repository).delete(id);
-        target.delete(id);
-        Mockito.verify(repository, Mockito.times(1)).delete(id);
+        AccountSelector selector = new AccountSelector();
+        Mockito.doNothing().when(repository).delete(selector);
+        target.delete(selector);
+        Mockito.verify(repository, Mockito.times(1)).delete(selector);
     }
 }


### PR DESCRIPTION
close #29 
実装と単体テスト

## todo
account delete時に外部キーで参照されてるレコードを先に削除する