### PR TITLE
Feat: account find one with name and owner

### DIFF
--- a/src/main/java/com/example/moneyAllocation/controller/AccountController.java
+++ b/src/main/java/com/example/moneyAllocation/controller/AccountController.java
@@ -2,6 +2,7 @@ package com.example.moneyAllocation.controller;
 
 import com.example.moneyAllocation.domain.Account;
 import com.example.moneyAllocation.domain.AccountSelector;
+import com.example.moneyAllocation.exception.BudRequestException;
 import com.example.moneyAllocation.security.LoginUserDetails;
 import com.example.moneyAllocation.service.AccountService;
 import java.util.List;
@@ -34,10 +35,17 @@ public class AccountController {
     }
 
     @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Account findOne(@AuthenticationPrincipal LoginUserDetails loginUserDetails, @RequestParam Long id) {
+    public Account findOne(@AuthenticationPrincipal LoginUserDetails loginUserDetails,
+                           @RequestParam(required = false) Long id, @RequestParam(required = false) String name) {
+
+        if (id == null && name == null) {
+            throw new BudRequestException("id, nameがともにnullで渡されました．");
+        }
+
         AccountSelector selector = new AccountSelector();
         selector.setOwnerId(loginUserDetails.getLoginUser().id());
         selector.setId(id);
+        selector.setName(name);
         return service.findOne(selector);
     }
 
@@ -61,5 +69,4 @@ public class AccountController {
         this.service.delete(selector);
     }
 }
-
 

--- a/src/main/java/com/example/moneyAllocation/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/example/moneyAllocation/controller/ApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.moneyAllocation.controller;
 
+import com.example.moneyAllocation.exception.BudRequestException;
 import com.example.moneyAllocation.exception.HealthDieException;
 import com.example.moneyAllocation.exception.ResourceNotFoundException;
 import com.example.moneyAllocation.exception.ResourceValidationException;
@@ -50,5 +51,11 @@ public class ApiExceptionHandler extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> handleUserRegisterException(
             UserRegisterException exception, WebRequest request) {
         return super.handleExceptionInternal(exception, exception.getMessage(), HttpHeaders.EMPTY, HttpStatus.FORBIDDEN, request);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> handleBudRequestException(
+            BudRequestException exception, WebRequest request) {
+        return super.handleExceptionInternal(exception, exception.getMessage(), HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request);
     }
 }

--- a/src/main/java/com/example/moneyAllocation/domain/AccountSelector.java
+++ b/src/main/java/com/example/moneyAllocation/domain/AccountSelector.java
@@ -5,6 +5,16 @@ public class AccountSelector {
 
     private Long id;
 
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/example/moneyAllocation/exception/BudRequestException.java
+++ b/src/main/java/com/example/moneyAllocation/exception/BudRequestException.java
@@ -1,0 +1,11 @@
+package com.example.moneyAllocation.exception;
+
+public class BudRequestException extends RuntimeException {
+    public BudRequestException(String message) {
+        super(message);
+    }
+
+    public BudRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.xml
+++ b/src/main/java/com/example/moneyAllocation/repository/mybatis/AccountMapper.xml
@@ -39,7 +39,12 @@
         FROM
         ACCOUNT
         <where>
-            ID = #{id}
+            <if test="id !=null">
+                AND ID = #{id}
+            </if>
+            <if test="name !=null">
+                AND NAME = #{name}
+            </if>
             AND OWNER_ID = #{ownerId}
         </where>
     </select>
@@ -57,7 +62,7 @@
         (
         #{name},
         <if test="numFreeTransfer != null">
-        #{numFreeTransfer},
+            #{numFreeTransfer},
         </if>
         <if test="numFreeTransfer == null">
             default,

--- a/src/test/java/com/example/moneyAllocation/controller/AccountControllerTest.java
+++ b/src/test/java/com/example/moneyAllocation/controller/AccountControllerTest.java
@@ -3,6 +3,7 @@ package com.example.moneyAllocation.controller;
 import static org.junit.jupiter.api.Assertions.*;
 import com.example.moneyAllocation.domain.Account;
 import com.example.moneyAllocation.domain.AccountSelector;
+import com.example.moneyAllocation.exception.BudRequestException;
 import com.example.moneyAllocation.security.LoginUser;
 import com.example.moneyAllocation.security.LoginUserDetails;
 import com.example.moneyAllocation.security.UserRole;
@@ -56,23 +57,47 @@ class AccountControllerTest {
     }
 
     @Test
-    void findOne() {
+    void findOneWithId() {
         Account findResult = new Account();
         findResult.setName("ryota");
 
         ArgumentMatcher<AccountSelector> matcher = argument -> {
             assertEquals(1L, argument.getOwnerId());
             assertEquals(2L, argument.getId());
+            assertNull(argument.getName());
             return true;
         };
         Mockito.doReturn(findResult).when(service).findOne(Mockito.argThat(matcher));
 
-        Account result = controller.findOne(loginUserDetails, 2L);
+        Account result = controller.findOne(loginUserDetails, 2L, null);
 
         assertEquals(findResult, result);
         Mockito.verify(service, Mockito.times(1)).findOne(Mockito.argThat(matcher));
     }
 
+    @Test
+    void findOneWithName() {
+        Account findResult = new Account();
+        findResult.setName("ryota");
+
+        ArgumentMatcher<AccountSelector> matcher = argument -> {
+            assertEquals(1L, argument.getOwnerId());
+            assertNull(argument.getId());
+            assertEquals("PayPay", argument.getName());
+            return true;
+        };
+        Mockito.doReturn(findResult).when(service).findOne(Mockito.argThat(matcher));
+
+        Account result = controller.findOne(loginUserDetails, null, "PayPay");
+
+        assertEquals(findResult, result);
+        Mockito.verify(service, Mockito.times(1)).findOne(Mockito.argThat(matcher));
+    }
+
+    @Test
+    void failFindOneIdAndNameAreNull() {
+        assertThrows(BudRequestException.class, () -> controller.findOne(loginUserDetails, null, null));
+    }
 
     @Test
     void add() {

--- a/src/test/java/com/example/moneyAllocation/repository/AccountRepositoryImplDbUnitTest.java
+++ b/src/test/java/com/example/moneyAllocation/repository/AccountRepositoryImplDbUnitTest.java
@@ -58,7 +58,7 @@ public class AccountRepositoryImplDbUnitTest {
         }
 
         @Test
-        public void testFindOne() {
+        public void testFindOneWithId() {
             AccountSelector selector = new AccountSelector();
             selector.setOwnerId(1L);
             selector.setId(1L);
@@ -69,6 +69,43 @@ public class AccountRepositoryImplDbUnitTest {
             assertEquals(150, account.getTransferFee());
             assertEquals(1L, account.getOwnerId());
         }
+
+        @Test
+        public void testFindOneWithName() {
+            AccountSelector selector = new AccountSelector();
+            selector.setOwnerId(1L);
+            selector.setName("三井");
+            Account account = repository.findOne(selector);
+            assertEquals(1L, account.getId());
+            assertEquals("三井", account.getName());
+            assertEquals(9999, account.getNumFreeTransfer());
+            assertEquals(150, account.getTransferFee());
+            assertEquals(1L, account.getOwnerId());
+        }
+
+        @Test
+        public void testFindOneWithNameAndId() {
+            AccountSelector selector = new AccountSelector();
+            selector.setOwnerId(1L);
+            selector.setName("三井");
+            selector.setId(1L);
+            Account account = repository.findOne(selector);
+            assertEquals(1L, account.getId());
+            assertEquals("三井", account.getName());
+            assertEquals(9999, account.getNumFreeTransfer());
+            assertEquals(150, account.getTransferFee());
+            assertEquals(1L, account.getOwnerId());
+        }
+
+        @Test
+        public void testFindOneWithInvalidNameAndId() {
+            AccountSelector selector = new AccountSelector();
+            selector.setOwnerId(1L);
+            selector.setName("三井");
+            selector.setId(2L);
+            assertThrows(ResourceNotFoundException.class, () -> repository.findOne(selector));
+        }
+
 
         @Test
         public void testFindOneWhenNotExists() {


### PR DESCRIPTION
### 実装
- [x] AccountSelectorにname追加
- [ ] accoundのfindOneでid，またはnameを指定して取れるように変更

### テスト
- AccountController.findOne()
  - [x] id指定, name:nullの場合の正常系
  - [x] id: null, name:指定の正常系
  - [x] id: null, name: nullの異常系
- AccountRepositoryImplDbUnit
  - [x] id指定, name:nullの場合の正常系
  - [x] id: null, name:指定の正常系
  - [x] id, name両方指定時の正常系
  - [x] id, name両方指定時の異常系
